### PR TITLE
Support annotating gallery images.

### DIFF
--- a/missingno.css
+++ b/missingno.css
@@ -1,7 +1,6 @@
 .missingno-annotation {
   z-index: 1;
   position: absolute;
-  bottom: 0;
   left: 0;
 
   background: #14171a;
@@ -14,4 +13,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
+}
+
+.AdaptiveMedia .missingno-annotation {
+  bottom: 0;
+}
+
+.Gallery-media .missingno-annotation {
+  top: 0;
 }

--- a/missingno.js
+++ b/missingno.js
@@ -1,9 +1,9 @@
 const addAnotations = () => {
   const images = document.querySelectorAll('.tweet .AdaptiveMedia img')
-  const galleryImages = document.querySelectorAll('.tweet .GalleryMedia img')
+  const galleryImages = document.querySelectorAll('.Gallery-media img')
   
   Array.from(images)
-    .concat(Array.from(galleryImages)
+    .concat(Array.from(galleryImages))
     .filter(image => !image.getAttribute('data-missingno-annotated'))
     .map(image => {
       image.setAttribute('data-missingno-annotated', true);

--- a/missingno.js
+++ b/missingno.js
@@ -1,8 +1,9 @@
 const addAnotations = () => {
-  const selector = '.tweet .AdaptiveMedia img';
-  const images = document.querySelectorAll(selector)
-
+  const images = document.querySelectorAll('.tweet .AdaptiveMedia img')
+  const galleryImages = document.querySelectorAll('.tweet .GalleryMedia img')
+  
   Array.from(images)
+    .concat(Array.from(galleryImages)
     .filter(image => !image.getAttribute('data-missingno-annotated'))
     .map(image => {
       image.setAttribute('data-missingno-annotated', true);


### PR DESCRIPTION
Twitter's gallery view inserts a new top-level div to show the selected image. This adds support for annotating those.

Example: https://twitter.com/joseinextdoor/status/987891789934755840

With the current version of this extension it only shows the annotation in the multi-image view and not when the images are selected (making most of the annotations unreadable).