### PR TITLE
Refactor for performance

### DIFF
--- a/missingno.js
+++ b/missingno.js
@@ -18,18 +18,18 @@ const callback = (mutations) => {
     // We're only interested in the nodes that were added by this mutationRecord
     const elements = Array.from(record.addedNodes)
       // We only care about nodes that are also Elements (nodeType 1)
-      .filter(node => node.nodeType === 1)
+      .filter(node => node.nodeType === 1);
 
     // Use imgSelectors to create an array of images we can add annotations to
-    const targetImgs = []
+    const targetImgs = [];
     imgSelectors.forEach(selector => {
       elements.forEach(element => {
         Array.from(element.querySelectorAll(selector))
           .forEach(selectedElem => {
-            targetImgs.push(selectedElem)
-          })
-      })
-    })
+            targetImgs.push(selectedElem);
+          });
+      });
+    });
     // Finally, filter out images without alt text and add the annotations
     targetImgs.filter(image => image.alt !== '').forEach(addAnotation)
   });

--- a/missingno.js
+++ b/missingno.js
@@ -13,10 +13,27 @@ const imgSelectors = [
   '.tweet .AdaptiveMedia img'
 ];
 
+const callback = (mutations) => {
+  mutations.forEach(record => {
+    // We're only interested in the nodes that were added by this mutationRecord
+    const elements = Array.from(record.addedNodes)
+      // We only care about nodes that are also Elements (nodeType 1)
+      .filter(node => node.nodeType === 1)
 
-const observer = new MutationObserver(mutations => {
-  mutations.forEach(() => addAnotations());
-});
+    // Use imgSelectors to create an array of images we can add annotations to
+    const targetImgs = []
+    imgSelectors.forEach(selector => {
+      elements.forEach(element => {
+        Array.from(element.querySelectorAll(selector))
+          .forEach(selectedElem => {
+            targetImgs.push(selectedElem)
+          })
+      })
+    })
+    // Finally, filter out images without alt text and add the annotations
+    targetImgs.filter(image => image.alt !== '').forEach(addAnotation)
+  });
+};
 
 const config = {
   attributes: false,

--- a/missingno.js
+++ b/missingno.js
@@ -8,6 +8,10 @@ const addAnotation = (image) => {
   image.parentElement.appendChild(div);
 }
 
+// What elements are we looking for? Special images
+const imgSelectors = [
+  '.tweet .AdaptiveMedia img'
+];
 
 
 const observer = new MutationObserver(mutations => {

--- a/missingno.js
+++ b/missingno.js
@@ -24,7 +24,7 @@ const observer = new MutationObserver(mutations => {
 });
 
 const config = {
-  attributes: true,
+  attributes: false,
   childList: true,
   characterData: false,
   subtree: true,

--- a/missingno.js
+++ b/missingno.js
@@ -42,4 +42,16 @@ const config = {
   subtree: true,
 };
 
-observer.observe(document.body, config);
+// We want to target the observer to specific parts of the DOM tree
+// So we need more than one observer
+const targets = [
+  // Main page content container
+  document.querySelector('#doc'),
+  // Permalink content container
+  document.querySelector('#permalink-overlay')
+];
+
+targets.forEach(target => {
+  const observer = new MutationObserver(callback);
+  observer.observe(target, config);
+});

--- a/missingno.js
+++ b/missingno.js
@@ -1,23 +1,14 @@
-const addAnotations = () => {
-  const selector = '.tweet .AdaptiveMedia img';
-  const images = document.querySelectorAll(selector)
-
-  Array.from(images)
-    .filter(image => !image.getAttribute('data-missingno-annotated'))
-    .map(image => {
-      image.setAttribute('data-missingno-annotated', true);
-
-      if (image.alt === '') {
-        return;
-      }
-
-      const div = document.createElement('div');
-      div.classList.add('missingno-annotation');
-      div.innerHTML = image.alt;
-      div.title = image.alt;
-      image.parentElement.appendChild(div);
-    });
+// Add an anotation as a sibling to an image element
+const addAnotation = (image) => {
+  // Create an element to display the alt text
+  const div = document.createElement('div');
+  div.classList.add('missingno-annotation');
+  div.innerHTML = image.alt;
+  div.title = image.alt;
+  image.parentElement.appendChild(div);
 }
+
+
 
 const observer = new MutationObserver(mutations => {
   mutations.forEach(() => addAnotations());


### PR DESCRIPTION
I've started to notice that after using a single Twitter tab for a while, dramatic slowdowns would start to occur. Even performing simple actions such as liking a tweet could take multiple seconds with a pegged-out CPU in the worst-case scenarios. I decided to generate a performance profile to see what the bottleneck was and discovered that it was this extension that was responsible for a large part of the slowdown.

Inspecting the code, I saw that it uses a MutationObserver to annotate new images as they are added to the DOM. I have[ experience working with MutationObservers](https://gist.github.com/noahleigh/0c71909a860d15ea56fd), so I decided to see if I could replicate the behavior of this extension without the huge performance penalty.

This PR changes the operation of the extension in two ways:

1. https://github.com/hnrysmth/missingno/blob/bf0069903a04e38fb366b4c88e9bd7b34a8f891c/missingno.js#L33 Instead of targeting the entire `document.body` with the MutationObserver, use multiple observers to target specific branches of the DOM tree where we know the images we want to annotate will be under. In this case those are `#doc` for the main timeline and `#permalink-overlay` for viewing single tweets. These are defined in the array `targets`, making it straightforward to add more targets if necessary.

2. https://github.com/hnrysmth/missingno/blob/bf0069903a04e38fb366b4c88e9bd7b34a8f891c/missingno.js#L1-L3 Instead of trying to manipulate all the images in the DOM on every mutation event, we only really care about any *new* images that are added by each MutationRecord. The callback to a MutationObserver recieves an array of MutationRecords, and each MutationRecord has arrays for which nodes were added and which ones were removed. This PR focuses on the `nodesAdded` property to find the images we're looking for. The selectors for the image elements are defined in the array `imgSelectors`, making it straightforward to add more selectors if necessary.

According to my informal testing of rapidly scrolling down a media-heavy timeline, processor time decreased from ~580ms to ~2ms in `missingno.js` after making these changes!

This PR introduces merge conflicts with #1, but as I mentioned above, it should now be straightforward to add new places where images need annotations in the future, including gallery views.