### PR TITLE
Support Gallery View

### DIFF
--- a/missingno.js
+++ b/missingno.js
@@ -25,10 +25,16 @@ const callback = (mutations) => {
     const targetImgs = [];
     imgSelectors.forEach(selector => {
       elements.forEach(element => {
-        Array.from(element.querySelectorAll(selector))
-          .forEach(selectedElem => {
-            targetImgs.push(selectedElem);
-          });
+        // If element is an <img>, we can't use querySelectorAll on it,
+        if (element.tagName === 'IMG') {
+          // so we just add it directly to targetImgs
+          targetImgs.push(element);
+        } else {
+          Array.from(element.querySelectorAll(selector))
+            .forEach(selectedElem => {
+              targetImgs.push(selectedElem);
+            });
+        }
       });
     });
     // Finally, filter out images without alt text and add the annotations

--- a/missingno.js
+++ b/missingno.js
@@ -38,7 +38,9 @@ const callback = (mutations) => {
       });
     });
     // Finally, filter out images without alt text and add the annotations
-    targetImgs.filter(image => image.alt !== '').forEach(addAnotation)
+    targetImgs
+      .filter(image => image.alt !== '')
+      .forEach(addAnotation)
   });
 };
 

--- a/missingno.js
+++ b/missingno.js
@@ -11,7 +11,7 @@ const addAnotation = (image) => {
 // What elements are we looking for? Special images
 const imgSelectors = [
   '.tweet .AdaptiveMedia img',
-  '.Gallery-media img'
+  '.Gallery-media img.media-image'
 ];
 
 const callback = (mutations) => {

--- a/missingno.js
+++ b/missingno.js
@@ -55,7 +55,9 @@ const targets = [
   // Main page content container
   document.querySelector('#doc'),
   // Permalink content container
-  document.querySelector('#permalink-overlay')
+  document.querySelector('#permalink-overlay'),
+  // Gallery view
+  document.querySelector('.Gallery.with-tweet')
 ];
 
 targets.forEach(target => {

--- a/missingno.js
+++ b/missingno.js
@@ -34,13 +34,13 @@ const callback = (mutations) => {
             .forEach(selectedElem => {
               targetImgs.push(selectedElem);
             });
-        }
+        };
       });
     });
     // Finally, filter out images without alt text and add the annotations
     targetImgs
       .filter(image => image.alt !== '')
-      .forEach(addAnotation)
+      .forEach(addAnotation);
   });
 };
 


### PR DESCRIPTION
#2 broke merge compatibility for #1 , so I figured I ought to re-add that functionality to the code that I refactored. 

It was trickier than I assumed because the gallery image we're interested in cannot be selected in the manner set up by #2 , so I had to add some logic to handle that special case. 

The descriptions appear at the top of the gallery views so as to not interfere with the tweet text overlay at the bottom.