### PR TITLE
Handled emoji images edge case

### DIFF
--- a/missingno.js
+++ b/missingno.js
@@ -37,9 +37,12 @@ const callback = (mutations) => {
         };
       });
     });
-    // Finally, filter out images without alt text and add the annotations
     targetImgs
+      // Filter out images without alt text
       .filter(image => image.alt !== '')
+      // Filter out emoji images which do have alt text, but we don't want them
+      .filter(image => !Array.from(image.classList).includes('Emoji'))
+      // Finally add the annotation!
       .forEach(addAnotation);
   });
 };


### PR DESCRIPTION
A case that I overlooked when testing my refactoring is quoted tweets with emoji in them. Twitter displays emoji as `<img>` elements, and they include an `alt` attribute (just the emoji character itself), so the extension assumes they should be captioned when they should not.

Sample tweet: https://twitter.com/chordbug/status/1016471918080339968

This PR adds an exclusion for images with an `.Emoji` class.